### PR TITLE
feat: Cookbook Onboard (AI Assistant) integration

### DIFF
--- a/alkahest-mdbook/book.toml
+++ b/alkahest-mdbook/book.toml
@@ -15,3 +15,4 @@ available_themes = ["rust", "coal"]
 [output.html]
 mathjax-support = true
 cname = "alkahest.coophive.network"
+additional-js = ["theme/ask-cookbook.js"]

--- a/alkahest-mdbook/theme/ask-cookbook.js
+++ b/alkahest-mdbook/theme/ask-cookbook.js
@@ -1,0 +1,20 @@
+(function () {
+  const COOKBOOK_PUBLIC_API_KEY =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NmZiMTE5MTBkYmQ2MTkwYjgzZGIyYmMiLCJpYXQiOjE3Mjc3MzAwNjUsImV4cCI6MjA0MzMwNjA2NX0.yD2cb9bklEsN0D2wjeAtDCN1MsqB4KXW_eTiXLiv2QY";
+  var element = document.getElementById("__cookbook");
+  if (!element) {
+    element = document.createElement("div");
+    element.id = "__cookbook";
+    element.dataset.apiKey = COOKBOOK_PUBLIC_API_KEY;
+    document.body.appendChild(element);
+  }
+  var script = document.getElementById("__cookbook-script");
+  if (!script) {
+    script = document.createElement("script");
+    script.src =
+      "https://cdn.jsdelivr.net/npm/@cookbookdev/docsbot/dist/standalone/index.cjs.js";
+    script.id = "__cookbook-script";
+    script.defer = true;
+    document.body.appendChild(script);
+  }
+})();


### PR DESCRIPTION
## Preview
Preview link: https://docsbot-demo-git-alkahest-cookbookdev.vercel.app

## Ask Cookbook AI Assistant
Cookbook's Ask Cookbook AI assistant and co-pilot is trained on all existing Alkahest resources (source code, docs website, etc.) and is available as a standalone modal, embeddable as a button on any page (recommended for technical docs). It answers developer questions about using Alkahest, acting as an enhanced and streamlined technical documentation search tool as well as a Solidity coding co-pilot.

Ask Cookbook AI can also access context from thousands of data sources indexed by Cookbook.dev in addition to CoopHive-specific data sources, providing the best blockchain developer-focused answers of any chatbot on the market. Cookbook will assist in the tuning and calibration of the AI assistant to ensure the highest answer quality.

![image](https://github.com/user-attachments/assets/3cc8beb8-5850-40dc-acd1-5de74acb2d5a)